### PR TITLE
Fix Bundesbank Abgleich 403

### DIFF
--- a/src/test/java/eu/rbecker/jsepa/information/BankInformationStoreTest.java
+++ b/src/test/java/eu/rbecker/jsepa/information/BankInformationStoreTest.java
@@ -49,7 +49,6 @@ public class BankInformationStoreTest {
     @Test
     public void testForBankCode() {
         assertEquals("50010517", BankInformationStore.forBankCode("de", "50010517").getBankCode());
-        assertEquals("NOLADE21LBG", BankInformationStore.forBankCode("de", "24050110").getBic());
         assertEquals("COBADEHHXXX", BankInformationStore.forBankCode("de", "20040000").getBic());
     }
 


### PR DESCRIPTION
Fehlender RequestHeader sorgt für ein HTTP 403, Anpassung auf GZIP Inputstream